### PR TITLE
Add #ifdef for OSX

### DIFF
--- a/shen_run.c
+++ b/shen_run.c
@@ -6,7 +6,11 @@
 #include <sys/wait.h>
 #include <sys/stat.h>
 #include <fcntl.h>
-#include <pty.h>
+#ifdef __APPLE__
+  #include <util.h>
+#else
+  #include <pty.h>
+#endif
 #include <unistd.h>
 #include <errno.h>
 #include <signal.h>


### PR DESCRIPTION
@gravicappa this makes `shen_run` compilable on OSX without having to manually change the includes.